### PR TITLE
Add integration with restlib2 and django-preserialize for defining REST endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ python:
     - "2.6"
     - "2.7"
 env:
-    - DJANGO=1.4.5
-    - DJANGO=1.5.1
+    - DJANGO=1.4.10
+    - DJANGO=1.5.5
+    - DJANGO=1.6.1
 install:
     - pip install -q coveralls Django==$DJANGO --use-mirrors
+    - pip install -r requirements.txt
 script:
     - coverage run test_suite.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: python
+
 python:
     - "2.6"
     - "2.7"
+
 env:
     - DJANGO=1.4.10
     - DJANGO=1.5.5
     - DJANGO=1.6.1
+
 install:
     - pip install -q coveralls Django==$DJANGO --use-mirrors
     - pip install -r requirements.txt
+    - pip install flake8
+
+before_script:
+    - flake8 objectset
+
 script:
     - coverage run test_suite.py
+
 after_success:
     - coveralls

--- a/objectset/__init__.py
+++ b/objectset/__init__.py
@@ -6,11 +6,13 @@ __version_info__ = {
     'serial': 1
 }
 
+
 def get_version(short=False):
     assert __version_info__['releaselevel'] in ('alpha', 'beta', 'final')
     vers = ["%(major)i.%(minor)i.%(micro)i" % __version_info__]
     if __version_info__['releaselevel'] != 'final' and not short:
-        vers.append('%s%i' % (__version_info__['releaselevel'][0], __version_info__['serial']))
+        vers.append('%s%i' % (__version_info__['releaselevel'][0],
+                              __version_info__['serial']))
     return ''.join(vers)
 
 __version__ = get_version()

--- a/objectset/decorators.py
+++ b/objectset/decorators.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+
 def cached_property(func):
     @wraps(func)
     def inner(self, *args, **kwargs):

--- a/objectset/forms.py
+++ b/objectset/forms.py
@@ -8,7 +8,8 @@ def objectset_form_factory(Model, queryset=None):
     In addition, an optional queryset can be supplied to limit the choices
     for the objects.
 
-    This uses the generic `objects` field rathr
+    This uses the generic `objects` field rather being named after a specific
+    type.
     """
     # A few checks to keep things sane..
     if not issubclass(Model, ObjectSet):
@@ -19,12 +20,15 @@ def objectset_form_factory(Model, queryset=None):
     if queryset is None:
         queryset = instance._object_class._default_manager.all()
     elif queryset.model is not instance._object_class:
-        raise TypeError('ObjectSet of type {0}, not {1}'.format(instance._object_class.__name__, queryset.model.__name__))
+        raise TypeError('ObjectSet of type {0}, not {1}'
+                        .format(instance._object_class.__name__,
+                                queryset.model.__name__))
 
     label = getattr(Model, instance._set_object_rel).field.verbose_name
 
     class form_class(forms.ModelForm):
-        objects = forms.ModelMultipleChoiceField(queryset, label=label, required=False)
+        objects = forms.ModelMultipleChoiceField(queryset, label=label,
+                                                 required=False)
 
         def save(self, *args, **kwargs):
             self.instance._pending = self.cleaned_data.get('objects')

--- a/objectset/forms.py
+++ b/objectset/forms.py
@@ -31,7 +31,13 @@ def objectset_form_factory(Model, queryset=None):
                                                  required=False)
 
         def save(self, *args, **kwargs):
-            self.instance._pending = self.cleaned_data.get('objects')
+            objects = self.cleaned_data.get('objects')
+            # Django 1.4 nuance when working with an empty list. It is not
+            # properly defined an empty query set
+            if isinstance(objects, list) and not objects:
+                objects = self.instance.__class__.objects.none()
+
+            self.instance._pending = objects
             return super(form_class, self).save(*args, **kwargs)
 
         class Meta(object):

--- a/objectset/models.py
+++ b/objectset/models.py
@@ -88,7 +88,8 @@ class ObjectSet(models.Model):
     def __xor__(self, other):
         "Performs an exclusive union of this set and `other`."
         excluded = models.Q(pk__in=(other._objects & self._objects))
-        return self.__class__((other._objects | self._objects).exclude(excluded))
+        return self.__class__((other._objects | self._objects)
+                              .exclude(excluded))
 
     def __sub__(self, other):
         "Removes objects from this set that are in `other`."
@@ -125,12 +126,15 @@ class ObjectSet(models.Model):
             m2m_fields = self._meta.many_to_many
             if not m2m_fields:
                 raise ImproperlyConfigured('At least one many-to-many '
-                    'relationship must exist on object sets.')
+                                           'relationship must exist on object '
+                                           'sets.')
             if len(m2m_fields) != 1:
                 raise ImproperlyConfigured('No explicit set object relation '
-                    'has been defined, but more than one many-to-many '
-                    'relationship exists on this object set. Define '
-                    '`set_object_rel` name on the class.')
+                                           'has been defined, but more than '
+                                           'one many-to-many relationship '
+                                           'exists on this object set. Define '
+                                           '`set_object_rel` name on the '
+                                           'class.')
             self.set_object_rel = m2m_fields[0].name
         return self.set_object_rel
 
@@ -146,10 +150,12 @@ class ObjectSet(models.Model):
                 if field is None:
                     field = f
                     continue
-                raise ImproperlyConfigured('No explicit through model set field '
-                    'relation has been defined, but more than one exists.')
+                raise ImproperlyConfigured('No explicit through model set '
+                                           'field relation has been defined, '
+                                           'but more than one exists.')
         if field is None:
-            raise ImproperlyConfigured('No through model set field relation was found.')
+            raise ImproperlyConfigured('No through model set field relation '
+                                       'was found.')
         return field.name
 
     @cached_property
@@ -160,14 +166,17 @@ class ObjectSet(models.Model):
 
         field = None
         for f in through._meta.fields:
-            if isinstance(f, models.ForeignKey) and f.rel.to is self._object_class:
+            if isinstance(f, models.ForeignKey) and \
+                    f.rel.to is self._object_class:
                 if field is None:
                     field = f
                     continue
-                raise ImproperlyConfigured('No explicit through model object field '
-                    'relation has been defined, but more than one exists.')
+                raise ImproperlyConfigured('No explicit through model object '
+                                           'field relation has been defined, '
+                                           'but more than one exists.')
         if field is None:
-            raise ImproperlyConfigured('No through model object field relation was found.')
+            raise ImproperlyConfigured('No through model object field '
+                                       'relation was found.')
         return field.name
 
     @cached_property
@@ -225,8 +234,8 @@ class ObjectSet(models.Model):
 
     def _check_type(self, obj):
         if not isinstance(obj, self._object_class):
-            raise TypeError(u"Only objects of type '{0}' can be added to the "
-                "set".format(self._object_class.__name__))
+            raise TypeError("Only objects of type '{0}' can be added to the "
+                            "set".format(self._object_class.__name__))
 
     def _add(self, obj, added):
         """Check for an existing object that has been removed and mark
@@ -260,7 +269,8 @@ class ObjectSet(models.Model):
         super(ObjectSet, self).save(*args, **kwargs)
 
         # Handle pending data after the set has been saved
-        if self._pending is not None and not isinstance(self._pending, EmptyQuerySet):
+        if self._pending is not None \
+                and not isinstance(self._pending, EmptyQuerySet):
             pending = list(self._pending.only('pk'))
             self._pending = self._object_class.objects.none()
             if new and BULK_SUPPORTED:

--- a/objectset/models.py
+++ b/objectset/models.py
@@ -145,6 +145,7 @@ class ObjectSet(models.Model):
             return through.object_set_rel
 
         field = None
+
         for f in through._meta.fields:
             if isinstance(f, models.ForeignKey) and f.rel.to is self.__class__:
                 if field is None:
@@ -153,9 +154,11 @@ class ObjectSet(models.Model):
                 raise ImproperlyConfigured('No explicit through model set '
                                            'field relation has been defined, '
                                            'but more than one exists.')
+
         if field is None:
             raise ImproperlyConfigured('No through model set field relation '
                                        'was found.')
+
         return field.name
 
     @cached_property
@@ -165,18 +168,22 @@ class ObjectSet(models.Model):
             return through.object_set_rel
 
         field = None
+
         for f in through._meta.fields:
             if isinstance(f, models.ForeignKey) and \
                     f.rel.to is self._object_class:
                 if field is None:
                     field = f
                     continue
+
                 raise ImproperlyConfigured('No explicit through model object '
                                            'field relation has been defined, '
                                            'but more than one exists.')
+
         if field is None:
             raise ImproperlyConfigured('No through model object field '
                                        'relation was found.')
+
         return field.name
 
     @cached_property

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -1,0 +1,134 @@
+from django.conf.urls import patterns, url
+from django.http import HttpResponse
+from restlib2.resources import Resource
+from restlib2.http import codes
+from restlib2.params import Parametizer, param_cleaners
+from preserialize.serialize import serialize
+
+SET_OPERATIONS = {
+    'and': '__and__',
+    'or': '__or__',
+    'xor': '__xor__',
+    'sub': '__sub__',
+}
+
+INPLACE_SET_OPERATIONS = {
+    'and': '__iand__',
+    'or': '__ior__',
+    'xor': '__ixor__',
+    'sub': '__isub__',
+}
+
+
+class SetParametizer(Parametizer):
+    embed = False
+
+    def clean_embed(self, value):
+        return param_cleaners.clean_bool(value)
+
+
+class BaseSetResource(Resource):
+    parametizer = SetParametizer
+
+    model = None
+
+    template = None
+
+    object_template = None
+
+    form_class = None
+
+    def get_params(self, request):
+        return self.parametizer().clean(request.GET)
+
+    def get_serialize_template(self, request, **kwargs):
+        "Prepare the serialize template"
+        template = self.template or {}
+        relation = self.model._set_object_rel
+
+        if kwargs.get('embed', False):
+            template.setdefault('exclude', [relation])
+        elif self.object_template:
+            template.setdefault('related', {})
+            if relation not in template['related']:
+                template['related'][relation] = self.object_template
+
+    def get_queryset(self, request):
+        return self.model.objects.all()
+
+    def get_object(self, request, **kwargs):
+        try:
+            return self.get_queryset(request).get(**kwargs)
+        except self.model.DoesNotExist:
+            pass
+
+
+class SetsResource(BaseSetResource):
+    def get(self, request):
+        params = self.get_params(request)
+        template = self.get_serialize_template(request, **params)
+        return serialize(self.get_queryset(request), **template)
+
+    def post(self, request):
+        form = self.form_class(request.data)
+
+        if form.is_valid():
+            instance = form.save()
+            params = self.get_params(request)
+            template = self.get_serialize_template(request, **params)
+            return serialize(instance, **template)
+        return HttpResponse(dict(form.errors),
+                            status=codes.unprocessable_enity)
+
+
+class SetResource(BaseSetResource):
+    def is_not_found(self, request, response, pk):
+        instance = self.get_object(pk=pk)
+        if instance is None:
+            return True
+        request.instance = instance
+
+    def get(self, request, pk):
+        return serialize(request.instance, **self.template)
+
+    def put(self, request, pk):
+        form = self.form_class(request.data, instance=request.instance)
+        if form.is_valid():
+            form.save()
+            return HttpResponse(status=codes.no_content)
+        return HttpResponse(dict(form.errors),
+                            status=codes.unprocessable_enity)
+
+    def delete(self, request, pk):
+        request.instance.delete()
+        return HttpResponse(status=codes.no_content)
+
+
+class SetObjectsResource(BaseSetResource):
+    pass
+
+
+class SetOperationsResource(BaseSetResource):
+    def post(request, pk, *args):
+        pass
+
+
+def get_url_patterns(resources):
+    """Returns urlpatterns for the defined resources.
+
+    `resources` is a dict corresponding to each resource:
+
+        - `sets` => SetsResource
+        - `set` => SetResource
+        - `operations` => SetOperatiosnResource
+        - `objects` => SetObjectsResource
+
+    """
+    return patterns(
+        '',
+        url(r'^$', resources['sets'](), name='sets'),
+        url(r'^(?P<pk>\d+)/$', resources['set'](), name='set'),
+        url(r'^(?P<pk>\d+)/objects/$', resources['objects'](), name='objects'),
+        url(r'^(?P<pk>\d+)/(?:(and|or|xor|sub)/(\d+)/)+/$',
+            resources['operations'](), name='operations'),
+    )

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -94,6 +94,9 @@ def set_links_posthook(instance, attrs, request):
             'href': uri(reverse('{0}set'.format(prefix),
                         kwargs={'pk': instance.pk}))
         },
+        'parent': {
+            'href': uri(reverse('{0}sets'.format(prefix)))
+        },
         'objects': {
             'href': uri(reverse('{0}objects'.format(prefix),
                         kwargs={'pk': instance.pk})),

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -161,7 +161,7 @@ class SetsResource(BaseSetResource):
             template = self.get_serialize_template(request, **params)
             return serialize(instance, **template)
         return HttpResponse(dict(form.errors),
-                            status=codes.unprocessable_enity)
+                            status=codes.unprocessable_entity)
 
 
 class SetResource(BaseSetResource):
@@ -196,7 +196,7 @@ class SetResource(BaseSetResource):
             form.save()
             return HttpResponse(status=codes.no_content)
         return HttpResponse(dict(form.errors),
-                            status=codes.unprocessable_enity)
+                            status=codes.unprocessable_entity)
 
     def delete(self, request, pk):
         request.instance.delete()

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -150,9 +150,6 @@ class SetObjectsResource(BaseSetResource):
     pass
 
 
-class SetOperationsResource(BaseSetResource):
-    def post(request, pk, *args):
-        pass
 
 
 def get_url_patterns(Model, resources=None, prefix=None):
@@ -162,7 +159,6 @@ def get_url_patterns(Model, resources=None, prefix=None):
 
         - `sets` => SetsResource
         - `set` => SetResource
-        - `operations` => SetOperationsResource
         - `objects` => SetObjectsResource
 
     """
@@ -196,13 +192,6 @@ def get_url_patterns(Model, resources=None, prefix=None):
 
         resources['objects'] = DefaultSetObjectsResource
 
-    if 'operations' not in resources:
-        class DefaultSetOperationsResource(SetOperationsResource):
-            model = Model
-            form_class = default_form_class
-
-        resources['operations'] = DefaultSetOperationsResource
-
     # Define a prefix for the url names to prevent conflicts
     if not prefix:
         prefix = '{0}-'.format(Model.__name__.lower())
@@ -215,7 +204,4 @@ def get_url_patterns(Model, resources=None, prefix=None):
             name='{0}set'.format(prefix)),
         url(r'^(?P<pk>\d+)/objects/$', resources['objects'](),
             name='{0}objects'.format(prefix)),
-        url(r'^(?P<pk>\d+)/(?:(and|or|xor|sub)/(\d+)/)+/$',
-            resources['operations'](),
-            name='{0}operations'.format(prefix)),
     )

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -32,7 +32,7 @@ INPLACE_SET_OPERATIONS = {
 
 
 class SetParametizer(Parametizer):
-    embed = BoolParam(default=True)
+    embed = BoolParam()
 
 
 class BaseSetResource(Resource):

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -147,9 +147,20 @@ class SetResource(BaseSetResource):
 
 
 class SetObjectsResource(BaseSetResource):
-    pass
+    def is_not_found(self, request, response, pk):
+        instance = self.get_object(request, pk=pk)
+        if instance is None:
+            return True
+        request.instance = instance
 
+    def get_serialize_template(self, request, **kwargs):
+        return {'fields': [':local']}
 
+    def get(self, request, pk):
+        queryset = request.instance._objects
+        params = self.get_params(request)
+        template = self.get_serialize_template(request, **params)
+        return serialize(queryset, **template)
 
 
 def get_url_patterns(Model, resources=None, prefix=None):

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -64,7 +64,7 @@ def apply_operations(instance, operations, queryset=None):
                 raise ValueError('Set operand does not exist')
 
         # Treat operand as list of object ids
-        elif isinstance(operand, (list, tuple)) and operand:
+        elif isinstance(operand, (list, tuple)):
             operand = queryset.model(operand)
 
         else:

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -10,7 +10,7 @@ from django.conf.urls import patterns, url
 from django.http import HttpResponse
 from restlib2.resources import Resource
 from restlib2.http import codes
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, BoolParam
 from preserialize.serialize import serialize
 
 SET_OPERATIONS = {
@@ -29,10 +29,7 @@ INPLACE_SET_OPERATIONS = {
 
 
 class SetParametizer(Parametizer):
-    embed = False
-
-    def clean_embed(self, value):
-        return param_cleaners.clean_bool(value)
+    embed = BoolParam(default=True)
 
 
 class BaseSetResource(Resource):

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -178,7 +178,7 @@ class SetsResource(BaseSetResource):
 
         if form.is_valid():
             instance = form.save(commit=False)
-            if 'operations' in request.data:
+            if 'operations' in request.data and request.data['operations']:
                 queryset = self.get_queryset(request)
                 try:
                     apply_operations(instance, request.data['operations'],

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -178,6 +178,7 @@ class SetsResource(BaseSetResource):
 
         if form.is_valid():
             instance = form.save(commit=False)
+
             if 'operations' in request.data and request.data['operations']:
                 queryset = self.get_queryset(request)
                 try:
@@ -188,7 +189,9 @@ class SetsResource(BaseSetResource):
             instance.save()
             params = self.get_params(request)
             template = self.get_serialize_template(request, **params)
+
             return serialize(instance, **template)
+
         return HttpResponse(dict(form.errors),
                             status=codes.unprocessable_entity)
 
@@ -212,18 +215,22 @@ class SetResource(BaseSetResource):
 
         instance = request.instance
         queryset = self.get_queryset(request)
+
         try:
             apply_operations(instance, request.data, queryset=queryset)
             instance.save()
         except ValueError:
             return HttpResponse(status=codes.unprocessable_entity)
+
         return HttpResponse(status=codes.no_content)
 
     def put(self, request, pk):
         form = self.form_class(request.data, instance=request.instance)
+
         if form.is_valid():
             form.save()
             return HttpResponse(status=codes.no_content)
+
         return HttpResponse(dict(form.errors),
                             status=codes.unprocessable_entity)
 

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -177,7 +177,15 @@ class SetsResource(BaseSetResource):
         form = self.form_class(request.data)
 
         if form.is_valid():
-            instance = form.save()
+            instance = form.save(commit=False)
+            if 'operations' in request.data:
+                queryset = self.get_queryset(request)
+                try:
+                    apply_operations(instance, request.data['operations'],
+                                     queryset=queryset)
+                except ValueError:
+                    return HttpResponse(status=codes.unprocessable_entity)
+            instance.save()
             params = self.get_params(request)
             template = self.get_serialize_template(request, **params)
             return serialize(instance, **template)

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -129,7 +129,9 @@ class SetResource(BaseSetResource):
         request.instance = instance
 
     def get(self, request, pk):
-        return serialize(request.instance, **self.template)
+        params = self.get_params(request)
+        template = self.get_serialize_template(request, **params)
+        return serialize(request.instance, **template)
 
     def put(self, request, pk):
         form = self.form_class(request.data, instance=request.instance)

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -123,7 +123,7 @@ class SetsResource(BaseSetResource):
 
 class SetResource(BaseSetResource):
     def is_not_found(self, request, response, pk):
-        instance = self.get_object(pk=pk)
+        instance = self.get_object(request, pk=pk)
         if instance is None:
             return True
         request.instance = instance

--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -1,3 +1,11 @@
+from django.core.exceptions import ImproperlyConfigured
+try:
+    import restlib2  # noqa
+    import preserialize  # noqa
+except ImportError:
+    raise ImproperlyConfigured('restlib2 and django-preserialize must be '
+                               'installed to use the resource classes')
+
 from django.conf.urls import patterns, url
 from django.http import HttpResponse
 from restlib2.resources import Resource

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+restlib2>=0.3.9,<0.4
+django-preserialize>=1.0.4,<1.1

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,23 @@ from setuptools import setup, find_packages
 
 kwargs = {
     # Packages
-    'packages': find_packages(exclude=['tests', '*.tests', '*.tests.*', 'tests.*']),
+    'packages': find_packages(exclude=[
+        'tests',
+        '*.tests',
+        '*.tests.*',
+        'tests.*',
+    ]),
     'include_package_data': True,
 
     # Dependencies
-    'install_requires': ['django'],
+    'install_requires': [
+        'django>=1.4',
+    ],
+
+    'tests_require': [
+        'restlib>=0.3.9,<0.4',
+        'django-preserialize>=1.0.4,<1.1',
+    ],
 
     'test_suite': 'test_suite',
 
@@ -18,7 +30,7 @@ kwargs = {
     'description': 'ObjectSet abstract class for set-like models',
     'license': 'BSD',
     'keywords': 'object set',
-    'url': 'http://cbmi.github.com/django-objectset/',
+    'url': 'http://cbmi.github.io/django-objectset/',
     'classifiers': [
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: BSD License',

--- a/test_suite.py
+++ b/test_suite.py
@@ -1,6 +1,13 @@
 import os
+import sys
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 
 from django.core import management
-management.call_command('test', 'tests')
+
+apps = sys.argv[1:]
+
+if not apps:
+        apps = ['tests']
+
+management.call_command('test', *apps, interactive=False)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,4 +12,7 @@ INSTALLED_APPS = (
 )
 
 
+ROOT_URLCONF = 'tests.urls'
+
+
 SECRET_KEY = 'abc123'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -441,14 +441,34 @@ class ResourcesTest(TestCase):
                                     content_type='application/json',
                                     HTTP_ACCEPT='application/json')
         data = json.loads(response.content)
-        self.assertEqual(data['objects'], [{'id': 1}, {'id': 2}, {'id': 3}])
+        self.assertEqual([o['id'] for o in data['objects']], [1, 2, 3])
 
+        s2 = RecordSet([4, 5, 6], save=True)
         response = self.client.post('/?embed=1',
-                                    json.dumps({'objects': [1, 2, 3]}),
+                                    json.dumps({
+                                        'objects': [1, 2, 3],
+                                        'operations': [
+                                            {'set': s2.pk, 'operator': 'or'}
+                                        ],
+                                    }),
                                     content_type='application/json',
                                     HTTP_ACCEPT='application/json')
         data = json.loads(response.content)
-        self.assertEqual(data['objects'], [{'id': 1}, {'id': 2}, {'id': 3}])
+        self.assertEqual([o['id'] for o in data['objects']],
+                         [1, 2, 3, 4, 5, 6])
+
+        s2 = RecordSet([4, 5, 6], save=True)
+        response = self.client.post('/?embed=1',
+                                    json.dumps({
+                                        'operations': [
+                                            {'set': s2.pk, 'operator': 'or'}
+                                        ],
+                                    }),
+                                    content_type='application/json',
+                                    HTTP_ACCEPT='application/json')
+        data = json.loads(response.content)
+        self.assertEqual([o['id'] for o in data['objects']],
+                         [4, 5, 6])
 
     def test_get_set(self):
         RecordSet([1, 2, 3], save=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,3 @@
-import time
 import json
 from django.test import TestCase
 from django.db import IntegrityError
@@ -239,30 +238,6 @@ class SetTestCase(TestCase):
         self.assertEqual(s.count, 0)
 
         self.assertEqual(s._set_objects().count(), 0)
-
-    def test_perf(self):
-        "Compares performance of bulk load vs. an update"
-        s = SimpleRecordSet()
-        s.save()
-
-        Record.objects.all().delete()
-
-        # Only test 100. SQLite limitation..
-        objs = [Record(pk=i) for i in xrange(100)]
-        Record.objects.bulk_create(objs)
-
-        t0 = time.time()
-        s.update(objs)
-        t1 = time.time() - t0
-
-        s._set_objects().delete()
-
-        t0 = time.time()
-        s.bulk(objs)
-        t2 = time.time() - t0
-
-        # 10-fold difference
-        self.assertTrue(t2 * 10 < t1)
 
     def test_iter(self):
         s = SimpleRecordSet()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -57,7 +57,9 @@ class SetTestCase(TestCase):
 
     def test_repr(self):
         objs = [Record(pk=i) for i in xrange(1, 5)]
-        self.assertEqual(repr(SimpleRecordSet(objs)), 'SimpleRecordSet([<Record: 1>, <Record: 2>, <Record: 3>, <Record: 4>])')
+        self.assertEqual(repr(SimpleRecordSet(objs)),
+                         'SimpleRecordSet([<Record: 1>, <Record: 2>, '
+                         '<Record: 3>, <Record: 4>])')
 
     def test_and(self):
         s1 = SimpleRecordSet([Record(pk=i) for i in xrange(1, 5)], save=True)
@@ -332,7 +334,8 @@ class SetObjectSetTestCase(TestCase):
 
         s.bulk([Record(pk=i) for i in xrange(3)])
         self.assertEqual(s.count, 3)
-        self.assertEqual(s.replace([Record(pk=i) for i in xrange(2, 6)], delete=True), 4)
+        self.assertEqual(s.replace([Record(pk=i) for i in xrange(2, 6)],
+                                   delete=True), 4)
         self.assertEqual(s.count, 4)
 
         # Original ones removed
@@ -395,7 +398,10 @@ class SetFormTest(TestCase):
         form = CustomRecordSetForm(data={'objects': range(1, 5)})
         self.assertFalse(form.is_valid())
 
-        form = CustomRecordSetForm(data={'objects': range(1, 5), 'name': 'Foo'})
+        form = CustomRecordSetForm(data={
+            'objects': range(1, 5),
+            'name': 'Foo',
+        })
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data['name'], 'Foo')
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -454,22 +454,19 @@ class ResourcesTest(TestCase):
 
     def test_put_set(self):
         s = RecordSet([1, 2, 3], save=True)
-        self.client.put('/1/', json.dumps({'objects': [4, 5, 6]}),
-                        content_type='application/json',
-                        HTTP_ACCEPT='application/json')
-
-        self.assertEqual([o.pk for o in s], [4, 5, 6])
-
-    def test_post_set(self):
-        s = RecordSet([1, 2, 3], save=True)
         s2 = RecordSet([4, 5, 6], save=True)
+
         ops = [
             {'set': s2.pk, 'operator': 'or'},
             {'set': [2, 4, 6], 'operator': 'sub'},
         ]
-        self.client.post('/1/', json.dumps(ops),
-                         content_type='application/json',
-                         HTTP_ACCEPT='application/json')
+
+        self.client.put('/1/', json.dumps({
+                        'objects': [4, 5, 6],
+                        'operations': ops,
+                        }),
+                        content_type='application/json',
+                        HTTP_ACCEPT='application/json')
 
         self.assertEqual([o.pk for o in s], [1, 3, 5])
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,5 @@
+from objectset.resources import get_url_patterns
+from .models import RecordSet
+
+
+urlpatterns = get_url_patterns(RecordSet)


### PR DESCRIPTION
This implements #1. One changes is that the resource that backed this URL structure `/<pk>/<op1>/<pk2>/[<op2>/<pk3>/, ...]` was not implemented. Instead the `SetsResource` and `SetResource` supports POST requests that take a series of operations to be applied to the target instance. In the former resource, this will be a new instance while the latter will be an existing one. This provides a high amount of flexibility for creating new sets since operations support logical AND, OR, and XOR as well as subtracting the right set from the left. Further sets can be either a list of object IDs or a primary key of a set instance.

Fix #1 
