### PR TITLE
Add support for protecting a resource by user or session

### DIFF
--- a/objectset/resources.py
+++ b/objectset/resources.py
@@ -111,7 +111,8 @@ class BaseSetResource(Resource):
 
             if field:
                 return True
-            elif self.user_support is True:
+
+            if self.user_support:
                 raise ImproperlyConfigured('user_support is set to true, but '
                                            '{0} does not have a `user` field'
                                            .format(self.model.__name__))
@@ -129,7 +130,7 @@ class BaseSetResource(Resource):
             if field:
                 return True
 
-            if self.session_support is True:
+            if self.session_support:
                 raise ImproperlyConfigured('session_support set to true, but '
                                            '{0} does not have a `session_key` '
                                            'field'.format(self.model.__name__))

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import User
 from objectset.models import ObjectSet, SetObject
 
 
@@ -20,4 +21,10 @@ class RecordSetObject(SetObject):
 
 
 class SimpleRecordSet(ObjectSet):
+    records = models.ManyToManyField(Record)
+
+
+class ProtectedRecordSet(ObjectSet):
+    user = models.ForeignKey(User, null=True, blank=True)
+    session_key = models.CharField(max_length=40, null=True, blank=True)
     records = models.ManyToManyField(Record)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,6 +8,9 @@ DATABASES = {
 }
 
 INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
     'tests',
 )
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,6 @@
 from objectset.resources import get_url_patterns
-from .models import RecordSet
+from .models import RecordSet, ProtectedRecordSet
 
 
-urlpatterns = get_url_patterns(RecordSet)
+urlpatterns = get_url_patterns(RecordSet) + \
+    get_url_patterns(ProtectedRecordSet, prefix='protected')


### PR DESCRIPTION
This introduces two resource properties `user_support` and `session_support`
which change the behavior of `get_queryset` (which all queries go through)
to limit results based on the user or session key of the request.

If either property is None, the resource will be checked for the `user`
and `session_key`, respectively, to determine if support should be enabled.
Either property can be explicitly False to disable the behavior.
